### PR TITLE
Added key bindings to improve usability

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,10 @@ A window will appear, displaying the list of names as defined in the file.
 ![Screen shot](screenshot.png "Screen shot")
 
 You can now select the desired names by clicking each of them while holding down
-the `CTRL` key. Click **Copy** to copy the list of selected list of reviewers to
-the clipboard. The tool will automatically preprend each line with the string
-`Reviewed-by: `. Example: clicking "Jane Doe" and "Paul Hacker" will result in
-the following clipboard content:
+the `CTRL` key. Click **Copy** or press `Ctrl+C` or `Alt+C` to copy the list of
+selected list of reviewers to the clipboard. The tool will automatically
+preprend each line with the string `Reviewed-by: `. Example: clicking "Jane Doe"
+and "Paul Hacker" will result in the following clipboard content:
 
 ```
 Reviewed-by: Jane Doe <jane.doe@foo.org>
@@ -50,7 +50,7 @@ Reviewed-by: Paul Hacker <paul@hacker.net>
 
 You can now paste the clipboard content into the merge commit message text.
 
-Click **Quit** to exit the application.
+Click **Quit** or press `Ctrl+Q` or `Alt+Q` to exit the application.
 
 ## Requirements
 

--- a/reviewers.py
+++ b/reviewers.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python3
 
 """
-Copyright (c) 2018 Lenz Grimmer
+Copyright (c) 2018-2020 Lenz Grimmer
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -24,7 +24,8 @@ SOFTWARE.
 
 import gi
 gi.require_version('Gtk', '3.0')
-from gi.repository import Gtk, Gdk
+gi.require_version('Keybinder', '3.0')
+from gi.repository import Gtk, Gdk, Keybinder
 import sys
 
 
@@ -32,6 +33,7 @@ class MyWindow(Gtk.Window):
 
     def __init__(self):
         Gtk.Window.__init__(self, title="Select Reviewers")
+        Keybinder.init()
 
         grid = Gtk.Grid()
         names = ['']
@@ -39,11 +41,13 @@ class MyWindow(Gtk.Window):
 
         self.clipboard = Gtk.Clipboard.get(Gdk.SELECTION_CLIPBOARD)
 
-        button_copy = Gtk.Button(label="Copy")
+        button_copy = Gtk.Button.new_with_mnemonic("_Copy")
         button_copy.connect("clicked", self.copy_button_clicked)
+        Keybinder.bind("<Ctrl>C", self.copy_button_clicked)
 
-        button_quit = Gtk.Button(label="Quit")
+        button_quit = Gtk.Button.new_with_mnemonic("_Quit")
         button_quit.connect("clicked", Gtk.main_quit)
+        Keybinder.bind("<Ctrl>Q", Gtk.main_quit)
 
         namelist = Gtk.ListStore(str)
         for name in readnames():


### PR DESCRIPTION
Added key bindings and mnemonics to support using the keyboard for copying and quitting the application: now one can use `Ctrl+C` or `Alt+C` for copying the selected entries into the clipboard, and `Ctrl+Q`
or `Alt+Q` to exit the application.

Signed-off-by: Lenz Grimmer <lenz@grimmer.com>